### PR TITLE
Port legacy C++ to Rust crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,23 @@ version = "0.1.0"
 [[package]]
 name = "sable-parser"
 version = "0.1.0"
+dependencies = [
+ "sable-common",
+]
+
+[[package]]
+name = "sable-report"
+version = "0.1.0"
+dependencies = [
+ "sable-common",
+]
 
 [[package]]
 name = "sablec"
 version = "0.1.0"
+dependencies = [
+ "sable-ast",
+ "sable-common",
+ "sable-parser",
+ "sable-report",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,14 @@
 [workspace]
-members = [ "crates/sable-ast", "crates/sable-common","crates/sable-parser", "sablec"]
+members = [
+  "crates/sable-ast",
+  "crates/sable-common",
+  "crates/sable-parser",
+  "crates/sable-report",
+  "sablec",
+]
 resolver = "3"
 
-[workspace.dependecies]
+[workspace.dependencies]
 getset = "0.1.6"
 smallvec = "1.15.1"
 typed-builder = "0.21.0"
@@ -11,3 +17,4 @@ anyhow = "1.0.98"
 sable-ast = { path = "crates/sable-ast" }
 sable-common = { path = "crates/sable-common" }
 sable-parser = { path = "crates/sable-parser" }
+sable-report = { path = "crates/sable-report" }

--- a/crates/sable-ast/src/lib.rs
+++ b/crates/sable-ast/src/lib.rs
@@ -1,14 +1,26 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
+pub trait Node {
+    fn accept(&self, visitor: &mut dyn AstVisitor);
+}
+
+pub trait AstVisitor {}
+
+pub struct Ast;
+
+impl Ast {
+    pub fn new() -> Self { Self }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
+    struct DummyVisitor;
+    impl AstVisitor for DummyVisitor {}
+    struct DummyNode;
+    impl Node for DummyNode {
+        fn accept(&self, _visitor: &mut dyn AstVisitor) {}
+    }
     #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+    fn ast_basic() {
+        let _ast = Ast::new();
     }
 }

--- a/crates/sable-common/src/lib.rs
+++ b/crates/sable-common/src/lib.rs
@@ -1,14 +1,50 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
+use std::rc::Rc;
+use std::ops::Range;
+
+#[derive(Debug, Clone)]
+pub struct Source {
+    pub content: String,
+    pub filename: String,
 }
+
+impl Source {
+    pub fn new(content: impl Into<String>, filename: impl Into<String>) -> Self {
+        Self { content: content.into(), filename: filename.into() }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct Manager {
+    contents: Vec<Rc<Source>>,
+}
+
+impl Manager {
+    pub fn new() -> Self {
+        Self { contents: Vec::new() }
+    }
+
+    pub fn add_content(&mut self, content: impl Into<String>, filename: impl Into<String>) -> Rc<Source> {
+        let src = Rc::new(Source::new(content, filename));
+        self.contents.push(Rc::clone(&src));
+        src
+    }
+
+    pub fn get_content(&self, filename: &str) -> Option<Rc<Source>> {
+        self.contents.iter().find(|s| s.filename == filename).map(|s| Rc::clone(s))
+    }
+}
+
+pub type RangeUsize = Range<usize>;
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+    fn manager_add_and_get() {
+        let mut mgr = Manager::new();
+        let src = mgr.add_content("hello", "file.sable");
+        let fetched = mgr.get_content("file.sable").unwrap();
+        assert!(Rc::ptr_eq(&src, &fetched));
     }
 }

--- a/crates/sable-parser/src/lib.rs
+++ b/crates/sable-parser/src/lib.rs
@@ -1,14 +1,189 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
+use sable_common::{Source, RangeUsize};
+use std::rc::Rc;
+
+#[derive(Debug, Clone)]
+pub struct Location {
+    pub file: Rc<Source>,
+    pub range: RangeUsize,
+}
+
+impl Location {
+    pub fn new(file: Rc<Source>, range: RangeUsize) -> Self {
+        Self { file, range }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenType {
+    Eof,
+    Unknown,
+    IntegerError,
+    FloatError,
+    Identifier,
+    Integer,
+    Float,
+    Comma,
+    Semicolon,
+    Plus,
+    Minus,
+    Star,
+    Slash,
+    Assign,
+}
+
+#[derive(Debug, Clone)]
+pub enum TokenData {
+    Int(i64),
+    Float(f64),
+}
+
+#[derive(Debug, Clone)]
+pub struct Token {
+    pub kind: TokenType,
+    pub location: Location,
+    pub lexeme: String,
+    pub data: Option<TokenData>,
+}
+
+pub struct Lexer {
+    source: Rc<Source>,
+    start: usize,
+    pos: usize,
+}
+
+impl Lexer {
+    pub fn new(source: Rc<Source>) -> Self {
+        Self { source, start: 0, pos: 0 }
+    }
+
+    fn make_location(&self) -> Location {
+        Location::new(Rc::clone(&self.source), self.start..self.pos)
+    }
+
+    fn make_lexeme(&self) -> &str {
+        &self.source.content[self.start..self.pos]
+    }
+
+    fn make_token(&self, kind: TokenType, data: Option<TokenData>) -> Token {
+        Token {
+            kind,
+            location: self.make_location(),
+            lexeme: self.make_lexeme().to_string(),
+            data,
+        }
+    }
+
+    fn get_char(&self, offset: usize) -> Option<char> {
+        self.source.content[self.pos + offset..].chars().next()
+    }
+
+    fn advance(&mut self) {
+        if let Some(c) = self.get_char(0) {
+            self.pos += c.len_utf8();
+        }
+    }
+
+    fn skip_trivial(&mut self) {
+        while let Some(c) = self.get_char(0) {
+            match c {
+                ' ' | '\t' | '\r' | '\n' => self.advance(),
+                _ => break,
+            }
+        }
+    }
+
+    fn lex_identifier(&mut self) -> Token {
+        while let Some(c) = self.get_char(0) {
+            if c.is_ascii_alphanumeric() || c == '_' {
+                self.advance();
+            } else {
+                break;
+            }
+        }
+        self.make_token(TokenType::Identifier, None)
+    }
+
+    fn lex_number(&mut self) -> Token {
+        let mut has_dot = false;
+        while let Some(c) = self.get_char(0) {
+            if c.is_ascii_digit() {
+                self.advance();
+            } else if c == '.' && !has_dot && self.get_char(c.len_utf8()).map_or(false, |n| n.is_ascii_digit()) {
+                has_dot = true;
+                self.advance();
+            } else {
+                break;
+            }
+        }
+        let lexeme = self.make_lexeme();
+        if has_dot {
+            match lexeme.parse::<f64>() {
+                Ok(f) => self.make_token(TokenType::Float, Some(TokenData::Float(f))),
+                Err(_) => self.make_token(TokenType::FloatError, None),
+            }
+        } else {
+            match lexeme.parse::<i64>() {
+                Ok(i) => self.make_token(TokenType::Integer, Some(TokenData::Int(i))),
+                Err(_) => self.make_token(TokenType::IntegerError, None),
+            }
+        }
+    }
+
+    fn lex(&mut self) -> Token {
+        self.skip_trivial();
+        self.start = self.pos;
+        let ch = match self.get_char(0) {
+            Some(c) => c,
+            None => return self.make_token(TokenType::Eof, None),
+        };
+        self.advance();
+        match ch {
+            'a'..='z' | 'A'..='Z' | '_' => self.lex_identifier(),
+            '0'..='9' => self.lex_number(),
+            ',' => self.make_token(TokenType::Comma, None),
+            ';' => self.make_token(TokenType::Semicolon, None),
+            '+' => self.make_token(TokenType::Plus, None),
+            '-' => self.make_token(TokenType::Minus, None),
+            '*' => self.make_token(TokenType::Star, None),
+            '/' => self.make_token(TokenType::Slash, None),
+            '=' => self.make_token(TokenType::Assign, None),
+            _ => self.make_token(TokenType::Unknown, None),
+        }
+    }
+
+    pub fn next(&mut self) -> Token {
+        self.lex()
+    }
+}
+
+pub struct Parser {
+    lexer: Lexer,
+}
+
+impl Parser {
+    pub fn new(lexer: Lexer) -> Self { Self { lexer } }
+    pub fn parse(&mut self) -> ParserStatus { ParserStatus::Ok }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParserStatus {
+    Ok,
+    OhNo,
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sable_common::Manager;
 
     #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+    fn lex_simple() {
+        let mut manager = Manager::new();
+        let src = manager.add_content("a = 1", "test.sable");
+        let mut lexer = Lexer::new(src);
+        let t1 = lexer.next();
+        assert_eq!(t1.kind, TokenType::Identifier);
+        let t2 = lexer.next();
+        assert_eq!(t2.kind, TokenType::Assign);
     }
 }

--- a/crates/sable-report/Cargo.toml
+++ b/crates/sable-report/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "sable-parser"
+name = "sable-report"
 version = "0.1.0"
 edition = "2024"
 

--- a/crates/sable-report/src/lib.rs
+++ b/crates/sable-report/src/lib.rs
@@ -1,0 +1,174 @@
+use sable_common::{Manager, RangeUsize, Source};
+use std::collections::HashMap;
+
+use std::io::{self, Write};
+use std::rc::Rc;
+
+#[derive(Debug, Clone)]
+pub struct Line {
+    pub range: RangeUsize,
+    pub line_number: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct CacheEntry {
+    pub source: Rc<Source>,
+    pub lines: Vec<Line>,
+}
+
+impl CacheEntry {
+    pub fn new(source: Rc<Source>) -> Self {
+        let mut lines = Vec::new();
+        let content = &source.content;
+        let mut start = 0;
+        for (idx, ch) in content.char_indices() {
+            if ch == '\n' {
+                lines.push(Line { range: start..idx, line_number: lines.len() + 1 });
+                start = idx + 1;
+            }
+        }
+        if start < content.len() {
+            lines.push(Line { range: start..content.len(), line_number: lines.len() + 1 });
+        }
+        Self { source, lines }
+    }
+
+    pub fn lines_for(&self, range: RangeUsize) -> &[Line] {
+        let mut first = None;
+        let mut last = None;
+        for (i, line) in self.lines.iter().enumerate() {
+            if line.range.start <= range.end && line.range.end > range.start {
+                if first.is_none() { first = Some(i); }
+                last = Some(i);
+            }
+        }
+        match (first, last) {
+            (Some(f), Some(l)) => &self.lines[f..=l],
+            _ => &[],
+        }
+    }
+}
+
+pub struct Cache<'a> {
+    pub manager: &'a Manager,
+    entries: HashMap<String, CacheEntry>,
+}
+
+impl<'a> Cache<'a> {
+    pub fn new(manager: &'a Manager) -> Self { Self { manager, entries: HashMap::new() } }
+
+    pub fn add_entry(&mut self, source: Rc<Source>) {
+        self.entries.entry(source.filename.clone()).or_insert_with(|| CacheEntry::new(source));
+    }
+
+    pub fn get_entry(&self, name: &str) -> Option<&CacheEntry> { self.entries.get(name) }
+}
+
+#[derive(Debug, Clone)]
+pub struct Span {
+    pub source: String,
+    pub range: RangeUsize,
+}
+
+impl Span {
+    pub fn new(source: String, range: RangeUsize) -> Self { Self { source, range } }
+}
+
+#[derive(Debug, Clone)]
+pub struct Label {
+    pub span: Span,
+    pub message: Option<String>,
+}
+
+impl Label {
+    pub fn new(span: Span) -> Self { Self { span, message: None } }
+    pub fn with_message(mut self, msg: impl Into<String>) -> Self { self.message = Some(msg.into()); self }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum Severity {
+    Info,
+    Warning,
+    Error,
+}
+
+#[derive(Debug, Clone)]
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub message: Option<String>,
+    pub code: Option<Span>,
+    pub labels: Vec<Label>,
+    pub note: Option<String>,
+}
+
+impl Diagnostic {
+    pub fn new(severity: Severity) -> Self {
+        Self { severity, message: None, code: None, labels: Vec::new(), note: None }
+    }
+
+    pub fn with_message(mut self, msg: impl Into<String>) -> Self { self.message = Some(msg.into()); self }
+    pub fn with_note(mut self, note: impl Into<String>) -> Self { self.note = Some(note.into()); self }
+    pub fn with_code(mut self, span: Span) -> Self { self.code = Some(span); self }
+    pub fn with_label(mut self, label: Label) -> Self { self.labels.push(label); self }
+}
+
+pub trait DiagnosticEngine {
+    fn report(&mut self, diag: &Diagnostic);
+}
+
+pub struct StreamWriter<'a, W: Write> {
+    writer: &'a mut W,
+    cache: &'a Cache<'a>,
+}
+
+impl<'a, W: Write> StreamWriter<'a, W> {
+    pub fn new(writer: &'a mut W, cache: &'a Cache<'a>) -> Self { Self { writer, cache } }
+}
+
+impl<'a, W: Write> DiagnosticEngine for StreamWriter<'a, W> {
+    fn report(&mut self, diag: &Diagnostic) {
+        let _ = write!(self.writer, "{:?}: ", diag.severity);
+        if let Some(msg) = &diag.message {
+            let _ = writeln!(self.writer, "{}", msg);
+        } else {
+            let _ = self.writer.write_all(b"\n");
+        }
+        if let Some(code) = &diag.code {
+            write_span(&mut *self.writer, code, self.cache).ok();
+        }
+        for label in &diag.labels {
+            write!(self.writer, "[Note]: ").ok();
+            if let Some(msg) = &label.message {
+                writeln!(self.writer, "{}", msg).ok();
+            }
+            write_span(&mut *self.writer, &label.span, self.cache).ok();
+        }
+    }
+}
+
+fn write_span<W: Write>(mut w: W, span: &Span, cache: &Cache<'_>) -> io::Result<()> {
+    if let Some(entry) = cache.get_entry(&span.source) {
+        if let Some(line) = entry.lines_for(span.range.clone()).first() {
+            let column = span.range.start - line.range.start + 1;
+            writeln!(w, "[{}:{}:{}]", span.source, line.line_number, column)?;
+            for l in entry.lines_for(span.range.clone()) {
+                let text = &entry.source.content[l.range.clone()];
+                writeln!(w, " {} | {}", l.line_number, text)?;
+                let mut underline = String::new();
+                let start = l.range.start;
+                let end = l.range.end;
+                for i in start..end {
+                    if i == span.range.start {
+                        underline.push('^');
+                    } else if i > span.range.start && i < span.range.end {
+                        underline.push('~');
+                    } else {
+                        underline.push(' ');
+                    }
+                }
+                writeln!(w, "   | {}", underline)?;
+            }
+        }
+    }
+    Ok(())
+}

--- a/sablec/Cargo.toml
+++ b/sablec/Cargo.toml
@@ -4,3 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+sable-common = { workspace = true }
+sable-parser = { workspace = true }
+sable-report = { workspace = true }
+sable-ast = { workspace = true }

--- a/sablec/src/main.rs
+++ b/sablec/src/main.rs
@@ -1,3 +1,23 @@
+use std::rc::Rc;
+use sable_common::Manager;
+use sable_parser::{Lexer, Parser, ParserStatus};
+use sable_ast::Ast;
+use sable_report::{Cache, StreamWriter, DiagnosticEngine};
+
 fn main() {
-    println!("Hello, world!");
+    let source = "sasd\nint a = 123; @";
+    let mut manager = Manager::new();
+    let src = manager.add_content(source, "main.sable");
+
+    let mut cache = Cache::new(&manager);
+    cache.add_entry(Rc::clone(&src));
+
+    let lexer = Lexer::new(Rc::clone(&src));
+    let mut ast = Ast::new();
+    let mut writer = StreamWriter::new(&mut std::io::stdout(), &cache);
+    let mut parser = Parser::new(lexer);
+    match parser.parse() {
+        ParserStatus::Ok => println!("Parsing completed successfully."),
+        ParserStatus::OhNo => println!("Parsing failed."),
+    }
 }


### PR DESCRIPTION
## Summary
- migrate workspace definitions and add `sable-report` crate
- implement source management in `sable-common`
- implement lexer and parser skeleton in `sable-parser`
- add minimal AST types
- implement diagnostic reporting crate
- create example main using new crates

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685820aa8f788333952a2aca5f124901