### PR TITLE
Fix lexer to use Arc<Source> lifetimes

### DIFF
--- a/crates/sable-common/src/source.rs
+++ b/crates/sable-common/src/source.rs
@@ -1,19 +1,23 @@
-use bumpalo::{Bump, collections::String as BumpString};
-use getset::Getters;
+use bumpalo::Bump;
 
-#[derive(Getters)]
 pub struct Source<'ctx> {
-  #[getset(get = "pub")]
-  content: BumpString<'ctx>,
-  #[getset(get = "pub")]
-  filename: BumpString<'ctx>,
+  content: &'ctx str,
+  filename: &'ctx str,
 }
 
 impl<'ctx> Source<'ctx> {
-  pub fn new(content: &str, filename: &str, bump: &'ctx Bump) -> Self {
+  pub fn new(content: &str, filename: &'ctx str, bump: &'ctx Bump) -> Self {
     Self {
-      content: BumpString::from_str_in(content, bump),
-      filename: BumpString::from_str_in(filename, bump),
+      content: bump.alloc_str(content),
+      filename,
     }
+  }
+
+  pub fn content(&self) -> &'ctx str {
+    self.content
+  }
+
+  pub fn filename(&self) -> &'ctx str {
+    self.filename
   }
 }

--- a/crates/sable-parser/src/lexer.rs
+++ b/crates/sable-parser/src/lexer.rs
@@ -1,11 +1,12 @@
+use std::sync::Arc;
+
 use sable_ast::location::Location;
 use sable_common::source::Source;
 
 use crate::token::{Token, TokenError, TokenKind};
 
 pub struct Lexer<'ctx> {
-  source: &'ctx Source<'ctx>,
-  raw: &'ctx str,
+  source: Arc<Source<'ctx>>,
 
   pos: usize,
   start: usize,
@@ -14,9 +15,8 @@ pub struct Lexer<'ctx> {
 }
 
 impl<'ctx> Lexer<'ctx> {
-  pub fn new(source: &'ctx Source<'ctx>) -> Self {
+  pub fn new(source: Arc<Source<'ctx>>) -> Self {
     let mut lexer = Self {
-      raw: source.content().as_str(),
       source,
 
       pos: 0,
@@ -28,8 +28,12 @@ impl<'ctx> Lexer<'ctx> {
     lexer
   }
 
+  fn source_content(&self) -> &'ctx str {
+    self.source.content()
+  }
+
   fn get_char(&self, offset: usize) -> Option<char> {
-    self.raw[self.pos + offset..].chars().next()
+    self.source_content()[self.pos + offset..].chars().next()
   }
 
   fn advance(&mut self) {
@@ -39,11 +43,11 @@ impl<'ctx> Lexer<'ctx> {
   }
 
   fn make_location(&self) -> Location<'ctx> {
-    Location::new(self.start..self.pos, self.source.filename().as_str())
+    Location::new(self.start..self.pos, self.source.filename())
   }
 
   fn make_lexeme(&self) -> &'ctx str {
-    &self.raw[self.start..self.pos]
+    &self.source_content()[self.start..self.pos]
   }
 
   fn make_token(&self, kind: TokenKind) -> Token<'ctx> {

--- a/sablec/src/main.rs
+++ b/sablec/src/main.rs
@@ -64,7 +64,7 @@ fn main() {
   let mut binding = io::stdout();
   let mut writer = DiagnosticWriter::new(&cache, &mut binding);
 
-  let mut lexer = Lexer::new(source.as_ref());
+  let mut lexer = Lexer::new(source.clone());
   while let Some(token) = lexer.next() {
     println!("{:?}", token);
     match token.kind().clone() {


### PR DESCRIPTION
## Summary
- refactor `Source` to store `&'ctx str` directly
- update `Lexer` to use the new safe accessors

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68593ba9fd648333b7736f2f73e25d10