### PR TITLE
Add numeric error handling

### DIFF
--- a/crates/sable-errors/src/lex_error/mod.rs
+++ b/crates/sable-errors/src/lex_error/mod.rs
@@ -1,1 +1,2 @@
 pub mod unknown_char;
+pub mod numeric_error;

--- a/crates/sable-errors/src/lex_error/numeric_error.rs
+++ b/crates/sable-errors/src/lex_error/numeric_error.rs
@@ -1,0 +1,26 @@
+use ariadne::{Label, Report, ReportKind};
+use sable_ast::location::Location;
+
+#[derive(Debug)]
+pub struct NumericError<'ctx> {
+    pub lexeme: &'ctx str,
+    pub location: Location,
+}
+
+impl<'ctx> NumericError<'ctx> {
+    pub fn new(lexeme: &'ctx str, location: Location) -> Self {
+        Self { lexeme, location }
+    }
+
+    pub fn report(&self) -> ariadne::Report<sable_common::FileSpan> {
+        let span = (
+            self.location.filename().clone(),
+            self.location.range().clone(),
+        );
+
+        Report::build(ReportKind::Error, span.clone())
+            .with_message(format!("Invalid number: `{}`", self.lexeme))
+            .with_label(Label::new(span).with_message("This number literal is invalid."))
+            .finish()
+    }
+}

--- a/crates/sable-errors/src/parse_error/mod.rs
+++ b/crates/sable-errors/src/parse_error/mod.rs
@@ -6,12 +6,16 @@ use sable_common::{
   writer::Reportable,
 };
 
-use crate::lex_error::unknown_char::UnknownCharError;
+use crate::lex_error::{
+    numeric_error::NumericError,
+    unknown_char::UnknownCharError,
+};
 
 #[derive(Debug)]
 pub enum ParseError<'ctx> {
   UnexpectedToken(unexpected_token::UnexpectedTokenError<'ctx>),
   UnknownChar(UnknownCharError<'ctx>),
+  NumericError(NumericError<'ctx>),
 }
 
 impl<'ctx> Reportable for ParseError<'ctx> {
@@ -19,6 +23,7 @@ impl<'ctx> Reportable for ParseError<'ctx> {
     match self {
       ParseError::UnexpectedToken(unexpected_token) => unexpected_token.report(),
       ParseError::UnknownChar(unknown_char) => unknown_char.report(),
+      ParseError::NumericError(numeric_error) => numeric_error.report(),
     }
   }
 }

--- a/crates/sable-parser/src/parser.rs
+++ b/crates/sable-parser/src/parser.rs
@@ -11,7 +11,10 @@ use sable_common::writer::{
   Sink,
 };
 use sable_errors::{
-  lex_error::unknown_char::UnknownCharError,
+  lex_error::{
+    numeric_error::NumericError,
+    unknown_char::UnknownCharError,
+  },
   parse_error::{
     ParseError,
     unexpected_token::{
@@ -48,8 +51,12 @@ impl<'ctx, 'p> Parser<'ctx, 'p> {
         token.lexeme(),
         token.location().clone(),
       )),
-      TokenError::InvalidInteger => todo!(),
-      TokenError::InvalidFloat => todo!(),
+      TokenError::InvalidInteger | TokenError::InvalidFloat => {
+        ParseError::NumericError(NumericError::new(
+          token.lexeme(),
+          token.location().clone(),
+        ))
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- create a NumericError type for invalid numeric literals
- expose NumericError in parse error module
- return `ParseError::NumericError` from the parser when invalid numbers are lexed

## Testing
- `cargo check`
- `cargo fmt --all` *(fails: 'cargo-fmt' is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685ec4e34ee48333b5766d8b3b2b8753