### PR TITLE
Fix lifetime issues with DiagnosticEngine member

### DIFF
--- a/crates/sable-common/src/writer.rs
+++ b/crates/sable-common/src/writer.rs
@@ -52,9 +52,8 @@ where
     Self { sink }
   }
 
-  pub fn emit(&mut self, diag: impl Reportable) {
+  pub fn emit(&mut self, diag: impl Reportable) -> Result<(), S::Error> {
     let report = diag.report();
-    // Ignoring errors for now; diagnostics should not panic
-    let _ = self.sink.report(report);
+    self.sink.report(report)
   }
 }

--- a/crates/sable-common/src/writer.rs
+++ b/crates/sable-common/src/writer.rs
@@ -36,3 +36,25 @@ where
     report.write(&mut *self.cache, &mut *self.out)
   }
 }
+
+pub struct DiagnosticEngine<'d, S>
+where
+  S: Sink + ?Sized,
+{
+  sink: &'d mut S,
+}
+
+impl<'d, S> DiagnosticEngine<'d, S>
+where
+  S: Sink + ?Sized,
+{
+  pub fn new(sink: &'d mut S) -> Self {
+    Self { sink }
+  }
+
+  pub fn emit(&mut self, diag: impl Reportable) {
+    let report = diag.report();
+    // Ignoring errors for now; diagnostics should not panic
+    let _ = self.sink.report(report);
+  }
+}

--- a/crates/sable-parser/src/parser.rs
+++ b/crates/sable-parser/src/parser.rs
@@ -97,7 +97,9 @@ where
       let kind_tag = match Self::expect(&mut self.lexer, expected.clone()) {
         Ok(tok) => tok.kind().tag(),
         Err(error) => {
-          self.engine.emit(error);
+          if let Err(e) = self.engine.emit(error) {
+            eprintln!("failed to emit diagnostic: {:?}", e);
+          }
           status = ParseStatus::Error;
           continue;
         }

--- a/sablec/src/main.rs
+++ b/sablec/src/main.rs
@@ -5,7 +5,9 @@ use sable_ast::ast::Ast;
 use sable_common::{
   cache::AriadneCache,
   manager::Manager,
-  writer::ReportWriter,
+  writer::{
+    ReportWriter,
+  },
 };
 use sable_parser::{
   lexer::Lexer,


### PR DESCRIPTION
## Summary
- embed `DiagnosticEngine` inside `Parser` again
- narrow helper method borrows to the lexer so diagnostics can be emitted without borrow conflicts
- update `sablec` example for new `Parser` API

## Testing
- `cargo check`
- `cargo run -p sablec` *(fails at not yet implemented)*

------
https://chatgpt.com/codex/tasks/task_e_68616a19b7a483339b630b94c8580afd