### PR TITLE
Fix parser sync after parsing failure

### DIFF
--- a/crates/sable-parser/src/lexer.rs
+++ b/crates/sable-parser/src/lexer.rs
@@ -37,7 +37,12 @@ impl<'ctx> Lexer<'ctx> {
 
   #[inline]
   fn get_char(&self, offset: usize) -> Option<char> {
-    self.source.content()[self.pos + offset..].chars().next()
+    self
+      .source
+      .content()
+      .get(self.pos..)?
+      .chars()
+      .nth(offset)
   }
 
   #[inline]

--- a/crates/sable-parser/src/parser.rs
+++ b/crates/sable-parser/src/parser.rs
@@ -80,7 +80,7 @@ impl<'ctx, 'p> Parser<'ctx, 'p> {
   }
 
   fn sync(&mut self, expected: SmallVec<[TokenKind; MAX_INLINE_KINDS]>) {
-    //peek awlays returns a tokentype
+    // `peek` always returns a token
     loop {
       let next = self.lexer.peek();
       if expected.contains(&next.kind().tag()) {

--- a/crates/sable-parser/src/parser.rs
+++ b/crates/sable-parser/src/parser.rs
@@ -188,7 +188,9 @@ impl<'ctx, 'p> Parser<'ctx, 'p> {
       };
 
       if kind_tag == TokenKind::Eof {
-        println!("Reached end of file.");
+        if let ParseStatus::Success = status {
+          println!("Reached end of file.");
+        }
         break;
       }
 
@@ -202,6 +204,7 @@ impl<'ctx, 'p> Parser<'ctx, 'p> {
             Err(error) => {
               self.handle_parse_error(sink, error);
               status = ParseStatus::Error;
+              self.sync(expected.clone());
               continue;
             }
           }


### PR DESCRIPTION
## Summary
- when `parse_function` fails, advance the lexer past unexpected tokens before continuing
- only print end-of-file message when parsing succeeded

## Testing
- `cargo run -q --bin sablec`
- `cargo test -q`


------
https://chatgpt.com/codex/tasks/task_e_6863d5dc5a7c8333b0c6c5c841c6cce3