### PR TITLE
Add optional serde feature

### DIFF
--- a/crates/sable-ast/Cargo.toml
+++ b/crates/sable-ast/Cargo.toml
@@ -7,6 +7,10 @@ edition = "2024"
 getset = { workspace = true }
 sable-common = { workspace = true }
 ariadne = { workspace = true }
-smallvec = { workspace = true, features = ["serde"] }
+smallvec = { workspace = true }
 typed-builder = { workspace = true }
-serde = { workspace = true, features = ["derive", "rc"] }
+serde = { workspace = true, optional = true, features = ["derive", "rc"] }
+
+[features]
+default = []
+serde = ["dep:serde", "smallvec/serde"]

--- a/crates/sable-ast/src/ast.rs
+++ b/crates/sable-ast/src/ast.rs
@@ -2,11 +2,13 @@ use getset::{
   Getters,
   MutGetters,
 };
+#[cfg(feature = "serde")]
 use serde::Serialize;
 
 use crate::objects::function::Function;
 
-#[derive(Getters, MutGetters, Debug, Serialize)]
+#[derive(Getters, MutGetters, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct Ast {
   #[getset(get_mut = "pub", get = "pub")]
   funcs: Vec<Function>,

--- a/crates/sable-ast/src/location.rs
+++ b/crates/sable-ast/src/location.rs
@@ -2,9 +2,11 @@ use std::ops::Range;
 
 use getset::Getters;
 use sable_common::FileId;
+#[cfg(feature = "serde")]
 use serde::Serialize;
 
-#[derive(Getters, Default, Clone, Debug, PartialEq, Eq, Serialize)]
+#[derive(Getters, Default, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct Location {
   #[getset(get = "pub")]
   range: Range<usize>,

--- a/crates/sable-ast/src/objects/function.rs
+++ b/crates/sable-ast/src/objects/function.rs
@@ -1,6 +1,7 @@
 use std::rc::Rc;
 
 use getset::Getters;
+#[cfg(feature = "serde")]
 use serde::Serialize;
 use smallvec::SmallVec;
 use typed_builder::TypedBuilder;
@@ -15,7 +16,8 @@ use crate::{
 
 pub const MAX_INLINE_PARAMS: usize = 6;
 
-#[derive(Getters, TypedBuilder, Debug, Serialize)]
+#[derive(Getters, TypedBuilder, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct FunctionParam {
   #[getset(get = "pub")]
   name: Rc<str>,
@@ -35,7 +37,8 @@ impl From<TypeNamePair> for FunctionParam {
   }
 }
 
-#[derive(Getters, TypedBuilder, Debug, Serialize)]
+#[derive(Getters, TypedBuilder, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct Function {
   #[getset(get = "pub")]
   name: Rc<str>,

--- a/crates/sable-ast/src/token.rs
+++ b/crates/sable-ast/src/token.rs
@@ -1,4 +1,5 @@
 use getset::Getters;
+#[cfg(feature = "serde")]
 use serde::Serialize;
 
 use crate::{
@@ -6,14 +7,16 @@ use crate::{
   types::PrimitiveType,
 };
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub enum TokenError {
   UnknownCharacter,
   InvalidInteger,
   InvalidFloat,
 }
 
-#[derive(Default, Clone, Debug, PartialEq, Serialize)]
+#[derive(Default, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub enum TokenKind {
   // Special
   #[default]
@@ -58,8 +61,8 @@ impl TokenKind {
   }
 }
 
-#[derive(Getters, Default, Clone, Debug, Serialize)]
-
+#[derive(Getters, Default, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct Token<'ctx> {
   #[getset(get = "pub")]
   kind: TokenKind,

--- a/crates/sable-ast/src/types.rs
+++ b/crates/sable-ast/src/types.rs
@@ -1,17 +1,20 @@
 use std::rc::Rc;
 
 use getset::Getters;
+#[cfg(feature = "serde")]
 use serde::Serialize;
 use typed_builder::TypedBuilder;
 
 use crate::location::Location;
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub enum PrimitiveType {
   I32,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub enum Type {
   Invalid,
   Primitive(PrimitiveType),
@@ -25,6 +28,7 @@ impl From<PrimitiveType> for Type {
 }
 
 #[derive(TypedBuilder, Getters)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct TypeNamePair {
   #[getset(get = "pub")]
   name: Rc<str>,


### PR DESCRIPTION
## Summary
- add optional `serde` feature to `sable-ast`
- gate `Serialize` derives behind the feature

## Testing
- `cargo check`
- `cargo check -p sable-ast --features serde`


------
https://chatgpt.com/codex/tasks/task_e_6864089cf0208333bd41f72f1bf96b2a