### PR TITLE
Refine token equality handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,48 +255,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
-name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_macros",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared",
- "rand",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator",
- "phf_shared",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,21 +299,6 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rustix"
@@ -424,7 +367,6 @@ version = "0.1.0"
 dependencies = [
  "either",
  "getset",
- "phf",
  "sable-ast",
  "sable-common",
  "sable-errors",
@@ -482,12 +424,6 @@ checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "siphasher"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "smallvec"

--- a/crates/sable-ast/src/token.rs
+++ b/crates/sable-ast/src/token.rs
@@ -15,45 +15,9 @@ pub enum TokenError {
   InvalidFloat,
 }
 
-#[derive(Default, Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize))]
-pub enum TokenKind {
-  // Special
-  #[default]
-  Eof,
-  Error(TokenError),
-
-  // Values
-  Identifier,
-  Integer(i64),
-  Float(f64),
-
-  // Brackets
-  Paren(bool),
-  Brace(bool),
-
-  // Symbols
-  Comma,
-  Semicolon,
-
-  // Operators
-  Plus,
-  Minus,
-  Star,
-  Slash,
-  Assign,
-
-  // Keywords
-  Func,
-  Type(PrimitiveType),
-}
-
-impl Eq for TokenKind {}
-
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
-pub enum TokenTag {
+pub enum TokenKind {
   // Special
   Eof,
   Error,
@@ -83,33 +47,19 @@ pub enum TokenTag {
   Type,
 }
 
-impl Default for TokenTag {
+impl Default for TokenKind {
   fn default() -> Self {
-    TokenTag::Eof
+    TokenKind::Eof
   }
 }
 
-impl TokenKind {
-  pub fn tag(&self) -> TokenTag {
-    match self {
-      TokenKind::Eof => TokenTag::Eof,
-      TokenKind::Error(_) => TokenTag::Error,
-      TokenKind::Identifier => TokenTag::Identifier,
-      TokenKind::Integer(_) => TokenTag::Integer,
-      TokenKind::Float(_) => TokenTag::Float,
-      TokenKind::Paren(b) => TokenTag::Paren(*b),
-      TokenKind::Brace(b) => TokenTag::Brace(*b),
-      TokenKind::Comma => TokenTag::Comma,
-      TokenKind::Semicolon => TokenTag::Semicolon,
-      TokenKind::Plus => TokenTag::Plus,
-      TokenKind::Minus => TokenTag::Minus,
-      TokenKind::Star => TokenTag::Star,
-      TokenKind::Slash => TokenTag::Slash,
-      TokenKind::Assign => TokenTag::Assign,
-      TokenKind::Func => TokenTag::Func,
-      TokenKind::Type(_) => TokenTag::Type,
-    }
-  }
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+pub enum TokenData {
+  Error(TokenError),
+  Integer(i64),
+  Float(f64),
+  Type(PrimitiveType),
 }
 
 #[derive(Getters, Default, Clone, Debug)]
@@ -118,7 +68,7 @@ pub struct Token<'ctx> {
   #[getset(get = "pub")]
   kind: TokenKind,
   #[getset(skip)]
-  tag: TokenTag,
+  data: Option<TokenData>,
   #[getset(get = "pub")]
   lexeme: &'ctx str,
   #[getset(get = "pub")]
@@ -126,16 +76,16 @@ pub struct Token<'ctx> {
 }
 
 impl<'ctx> Token<'ctx> {
-  pub fn new(kind: TokenKind, lexeme: &'ctx str, location: Location) -> Self {
+  pub fn new(kind: TokenKind, data: Option<TokenData>, lexeme: &'ctx str, location: Location) -> Self {
     Self {
-      tag: kind.tag(),
       kind,
+      data,
       lexeme,
       location,
     }
   }
 
-  pub fn tag(&self) -> TokenTag {
-    self.tag
+  pub fn data(&self) -> Option<&TokenData> {
+    self.data.as_ref()
   }
 }

--- a/crates/sable-ast/src/token.rs
+++ b/crates/sable-ast/src/token.rs
@@ -57,6 +57,10 @@ impl PartialEq for TokenKind {
 }
 
 impl TokenKind {
+  pub const INTEGER: Self = Self::Integer(0);
+  pub const FLOAT: Self = Self::Float(0.0);
+  pub const TYPE: Self = Self::Type(PrimitiveType::I32);
+
   pub fn tag(&self) -> TokenKind {
     match self {
       TokenKind::Integer(_) => TokenKind::Integer(0),

--- a/crates/sable-ast/src/token.rs
+++ b/crates/sable-ast/src/token.rs
@@ -15,7 +15,7 @@ pub enum TokenError {
   InvalidFloat,
 }
 
-#[derive(Default, Clone, Debug)]
+#[derive(Default, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 pub enum TokenKind {
   // Special
@@ -50,23 +50,64 @@ pub enum TokenKind {
 
 impl Eq for TokenKind {}
 
-impl PartialEq for TokenKind {
-  fn eq(&self, other: &Self) -> bool {
-    std::mem::discriminant(self) == std::mem::discriminant(other)
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+pub enum TokenTag {
+  // Special
+  Eof,
+  Error,
+
+  // Values
+  Identifier,
+  Integer,
+  Float,
+
+  // Brackets
+  Paren(bool),
+  Brace(bool),
+
+  // Symbols
+  Comma,
+  Semicolon,
+
+  // Operators
+  Plus,
+  Minus,
+  Star,
+  Slash,
+  Assign,
+
+  // Keywords
+  Func,
+  Type,
+}
+
+impl Default for TokenTag {
+  fn default() -> Self {
+    TokenTag::Eof
   }
 }
 
 impl TokenKind {
-  pub const INTEGER: Self = Self::Integer(0);
-  pub const FLOAT: Self = Self::Float(0.0);
-  pub const TYPE: Self = Self::Type(PrimitiveType::I32);
-
-  pub fn tag(&self) -> TokenKind {
+  pub fn tag(&self) -> TokenTag {
     match self {
-      TokenKind::Integer(_) => TokenKind::Integer(0),
-      TokenKind::Float(_) => TokenKind::Float(0.0),
-      TokenKind::Type(_) => TokenKind::Type(PrimitiveType::I32),
-      _ => self.clone(),
+      TokenKind::Eof => TokenTag::Eof,
+      TokenKind::Error(_) => TokenTag::Error,
+      TokenKind::Identifier => TokenTag::Identifier,
+      TokenKind::Integer(_) => TokenTag::Integer,
+      TokenKind::Float(_) => TokenTag::Float,
+      TokenKind::Paren(b) => TokenTag::Paren(*b),
+      TokenKind::Brace(b) => TokenTag::Brace(*b),
+      TokenKind::Comma => TokenTag::Comma,
+      TokenKind::Semicolon => TokenTag::Semicolon,
+      TokenKind::Plus => TokenTag::Plus,
+      TokenKind::Minus => TokenTag::Minus,
+      TokenKind::Star => TokenTag::Star,
+      TokenKind::Slash => TokenTag::Slash,
+      TokenKind::Assign => TokenTag::Assign,
+      TokenKind::Func => TokenTag::Func,
+      TokenKind::Type(_) => TokenTag::Type,
     }
   }
 }
@@ -76,6 +117,8 @@ impl TokenKind {
 pub struct Token<'ctx> {
   #[getset(get = "pub")]
   kind: TokenKind,
+  #[getset(skip)]
+  tag: TokenTag,
   #[getset(get = "pub")]
   lexeme: &'ctx str,
   #[getset(get = "pub")]
@@ -85,9 +128,14 @@ pub struct Token<'ctx> {
 impl<'ctx> Token<'ctx> {
   pub fn new(kind: TokenKind, lexeme: &'ctx str, location: Location) -> Self {
     Self {
+      tag: kind.tag(),
       kind,
       lexeme,
       location,
     }
+  }
+
+  pub fn tag(&self) -> TokenTag {
+    self.tag
   }
 }

--- a/crates/sable-ast/src/token.rs
+++ b/crates/sable-ast/src/token.rs
@@ -15,7 +15,7 @@ pub enum TokenError {
   InvalidFloat,
 }
 
-#[derive(Default, Clone, Debug, PartialEq)]
+#[derive(Default, Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 pub enum TokenKind {
   // Special
@@ -49,6 +49,12 @@ pub enum TokenKind {
 }
 
 impl Eq for TokenKind {}
+
+impl PartialEq for TokenKind {
+  fn eq(&self, other: &Self) -> bool {
+    std::mem::discriminant(self) == std::mem::discriminant(other)
+  }
+}
 
 impl TokenKind {
   pub fn tag(&self) -> TokenKind {

--- a/crates/sable-errors/src/parse_error/unexpected_token.rs
+++ b/crates/sable-errors/src/parse_error/unexpected_token.rs
@@ -5,7 +5,7 @@ use ariadne::{
 };
 use sable_ast::token::{
   Token,
-  TokenKind,
+  TokenTag,
 };
 use sable_common::{
   FileSpan,
@@ -17,12 +17,12 @@ pub const MAX_INLINE_KINDS: usize = 8;
 
 #[derive(Debug)]
 pub struct UnexpectedTokenError<'ctx> {
-  expected: SmallVec<[TokenKind; MAX_INLINE_KINDS]>,
+  expected: SmallVec<[TokenTag; MAX_INLINE_KINDS]>,
   found: Token<'ctx>,
 }
 
 impl<'ctx> UnexpectedTokenError<'ctx> {
-  pub fn new(expected: SmallVec<[TokenKind; MAX_INLINE_KINDS]>, found: Token<'ctx>) -> Self {
+  pub fn new(expected: SmallVec<[TokenTag; MAX_INLINE_KINDS]>, found: Token<'ctx>) -> Self {
     Self { expected, found }
   }
 }

--- a/crates/sable-errors/src/parse_error/unexpected_token.rs
+++ b/crates/sable-errors/src/parse_error/unexpected_token.rs
@@ -5,7 +5,7 @@ use ariadne::{
 };
 use sable_ast::token::{
   Token,
-  TokenTag,
+  TokenKind,
 };
 use sable_common::{
   FileSpan,
@@ -17,12 +17,12 @@ pub const MAX_INLINE_KINDS: usize = 8;
 
 #[derive(Debug)]
 pub struct UnexpectedTokenError<'ctx> {
-  expected: SmallVec<[TokenTag; MAX_INLINE_KINDS]>,
+  expected: SmallVec<[TokenKind; MAX_INLINE_KINDS]>,
   found: Token<'ctx>,
 }
 
 impl<'ctx> UnexpectedTokenError<'ctx> {
-  pub fn new(expected: SmallVec<[TokenTag; MAX_INLINE_KINDS]>, found: Token<'ctx>) -> Self {
+  pub fn new(expected: SmallVec<[TokenKind; MAX_INLINE_KINDS]>, found: Token<'ctx>) -> Self {
     Self { expected, found }
   }
 }

--- a/crates/sable-parser/Cargo.toml
+++ b/crates/sable-parser/Cargo.toml
@@ -10,5 +10,4 @@ sable-errors = { workspace = true }
 
 getset = { workspace = true }
 smallvec = { workspace = true }
-phf = { workspace = true, features = ["macros"]}
 either = { workspace = true }

--- a/crates/sable-parser/src/parser.rs
+++ b/crates/sable-parser/src/parser.rs
@@ -93,7 +93,7 @@ impl<'ctx, 'p> Parser<'ctx, 'p> {
       return Err(error);
     }
 
-    if expected.contains(&found.kind().tag()) {
+    if expected.contains(found.kind()) {
       return Ok(found);
     }
     let unexp = UnexpectedTokenError::new(expected, found);
@@ -103,7 +103,7 @@ impl<'ctx, 'p> Parser<'ctx, 'p> {
   fn sync(&mut self, expected: SmallVec<[TokenKind; MAX_INLINE_KINDS]>) {
     loop {
       let next = self.lexer.peek();
-      if expected.contains(&next.kind().tag()) {
+      if expected.contains(next.kind()) {
         return;
       }
       self.lexer.next();
@@ -112,8 +112,8 @@ impl<'ctx, 'p> Parser<'ctx, 'p> {
 
   fn peek(&self, expected: SmallVec<[TokenKind; MAX_INLINE_KINDS]>) -> Option<TokenKind> {
     let next = self.lexer.peek();
-    if expected.contains(&next.kind().tag()) {
-      Some(next.kind().tag())
+    if expected.contains(next.kind()) {
+      Some(next.kind().clone())
     } else {
       None
     }

--- a/crates/sable-parser/src/parser.rs
+++ b/crates/sable-parser/src/parser.rs
@@ -11,7 +11,6 @@ use sable_ast::{
     TokenKind,
   },
   types::{
-    PrimitiveType,
     Type,
     TypeNamePair,
   },
@@ -120,7 +119,7 @@ impl<'ctx, 'p> Parser<'ctx, 'p> {
   }
 
   fn parse_type(&mut self) -> Result<(Type, Location), ParseError<'ctx>> {
-    let expected = smallvec![TokenKind::Identifier, TokenKind::Type(PrimitiveType::I32)];
+    let expected = smallvec![TokenKind::Identifier, TokenKind::TYPE];
     let token = self.expect(expected)?;
 
     let start_loc = token.location();


### PR DESCRIPTION
## Summary
- adjust `TokenKind` equality to ignore variant data
- simplify parser token checks

## Testing
- `cargo test --all --quiet`
- `rustup component add rustfmt` *(fails: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_6864d1c060348333bf594a13018eae50