### PR TITLE
Switch AST functions to BumpVec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,9 @@ name = "bumpalo"
 version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cbindgen"
@@ -394,6 +397,7 @@ name = "sable-ast"
 version = "0.1.0"
 dependencies = [
  "ariadne",
+ "bumpalo",
  "getset",
  "sable-common",
  "serde",

--- a/crates/sable-ast/Cargo.toml
+++ b/crates/sable-ast/Cargo.toml
@@ -10,7 +10,8 @@ ariadne = { workspace = true }
 smallvec = { workspace = true }
 typed-builder = { workspace = true }
 serde = { workspace = true, optional = true, features = ["derive", "rc"] }
+bumpalo = { workspace = true, features = ["collections"] }
 
 [features]
 default = []
-serde = ["dep:serde", "smallvec/serde"]
+serde = ["dep:serde", "smallvec/serde", "bumpalo/serde"]

--- a/crates/sable-ast/src/ast.rs
+++ b/crates/sable-ast/src/ast.rs
@@ -5,17 +5,23 @@ use getset::{
 #[cfg(feature = "serde")]
 use serde::Serialize;
 
+use bumpalo::{
+  collections::Vec as BumpVec,
+  Bump,
+};
 use crate::objects::function::Function;
 
 #[derive(Getters, MutGetters, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
-pub struct Ast {
+pub struct Ast<'ctx> {
   #[getset(get_mut = "pub", get = "pub")]
-  funcs: Vec<Function>,
+  funcs: BumpVec<'ctx, Function>,
 }
 
-impl Ast {
-  pub fn new() -> Self {
-    Self { funcs: Vec::new() }
+impl<'ctx> Ast<'ctx> {
+  pub fn new(bump: &'ctx Bump) -> Self {
+    Self {
+      funcs: BumpVec::new_in(bump),
+    }
   }
 }

--- a/crates/sable-parser/src/parser.rs
+++ b/crates/sable-parser/src/parser.rs
@@ -66,11 +66,11 @@ fn expected_expression() -> SmallVec<[TokenKind; MAX_INLINE_KINDS]> {
 
 pub struct Parser<'ctx, 'p> {
   lexer: Lexer<'ctx>,
-  ast: &'p mut Ast,
+  ast: &'p mut Ast<'ctx>,
 }
 
 impl<'ctx, 'p> Parser<'ctx, 'p> {
-  pub fn new(lexer: Lexer<'ctx>, ast: &'p mut Ast) -> Self {
+  pub fn new(lexer: Lexer<'ctx>, ast: &'p mut Ast<'ctx>) -> Self {
     Self { lexer, ast }
   }
 

--- a/sablec/src/main.rs
+++ b/sablec/src/main.rs
@@ -51,7 +51,7 @@ fn main() {
   let mut writer = ReportWriter::new(&mut cache, &mut stdout);
 
   let lexer = Lexer::new(source.clone());
-  let mut ast = Ast::new();
+  let mut ast = Ast::new(&bump);
   let mut parser = SableParser::new(lexer, &mut ast);
   match parser.parse(&mut writer) {
     ParseStatus::Success => {


### PR DESCRIPTION
## Summary
- store functions in a bumpalo `BumpVec` instead of a standard `Vec`
- add `bumpalo` dependency to `sable-ast`
- update parser and driver for new AST type
- **use bumpalo's built-in serde support and keep original parser lifetime name**

## Testing
- `cargo check --all`
- `cargo test --all`


------
https://chatgpt.com/codex/tasks/task_e_686582fc82a483339ff0f80e0b4e0192