### PR TITLE
Refine arena to use runtime chunk size

### DIFF
--- a/crates/sable-arena/src/arena.rs
+++ b/crates/sable-arena/src/arena.rs
@@ -1,166 +1,260 @@
 extern crate alloc;
 
-use alloc::{
-  alloc::{
-    AllocError,
-    Allocator,
-    Global,
-  },
-  collections::LinkedList,
-};
+use alloc::{boxed::Box, vec::Vec};
 use core::{
-  alloc::Layout,
-  mem::{
-    self,
-    MaybeUninit,
-  },
-  ptr::{
-    self,
-    NonNull,
-  },
+    alloc::Layout,
+    cell::RefCell,
+    mem::{self, MaybeUninit},
+    ptr::{self, NonNull},
+    slice,
 };
 
-/// One arena chunk, with metadata at front
-struct BufNode {
-  size: usize,
+/// A chunk of raw memory backed by a leaked `Box`.
+struct Chunk {
+    /// Pointer to the start of the allocation.
+    storage: NonNull<u8>,
+    /// Total size of the chunk.
+    size: usize,
+    /// Current bump position.
+    pos: usize,
+    /// Raw handle used to reconstruct the box on drop.
+    raw: *mut [MaybeUninit<u8>],
 }
 
-pub struct Arena<A: Allocator = Global> {
-  allocator: A,
-  buffers: LinkedList<NonNull<BufNode>>,
-  offset: usize,
-}
-
-impl Arena<Global> {
-  pub fn new() -> Self {
-    Self::with_allocator(Global)
-  }
-}
-
-impl<A: Allocator + Clone> Arena<A> {
-  pub fn with_allocator(allocator: A) -> Self {
-    Self {
-      allocator,
-      buffers: LinkedList::new(),
-      offset: 0,
-    }
-  }
-
-  pub fn reset(&mut self) {
-    while let Some(ptr) = self.buffers.pop_front() {
-      unsafe {
-        let size = ptr.as_ref().size;
-        let layout = Layout::from_size_align_unchecked(size, 8);
-        self.allocator.deallocate(ptr.cast(), layout);
-      }
-    }
-    self.offset = 0;
-  }
-
-  #[inline(always)]
-  fn align_up(addr: usize, align: usize) -> usize {
-    (addr + align - 1) & !(align - 1)
-  }
-
-  fn ensure_capacity(&mut self, layout: Layout) -> Result<*mut u8, AllocError> {
-    let align = layout.align();
-    let size = layout.size();
-
-    if let Some(&ptr) = self.buffers.front() {
-      unsafe {
-        let base = (ptr.as_ptr() as *mut u8).add(mem::size_of::<BufNode>());
-        let capacity = ptr.as_ref().size - mem::size_of::<BufNode>();
-
-        let raw = base.add(self.offset);
-        let aligned = Self::align_up(raw as usize, align);
-        let end = aligned + size;
-
-        if end <= base as usize + capacity {
-          self.offset = end - base as usize;
-          return Ok(aligned as *mut u8);
+impl Chunk {
+    fn new(size: usize) -> Option<Self> {
+        if size == 0 {
+            return None;
         }
-      }
+        let boxed = vec![MaybeUninit::<u8>::uninit(); size].into_boxed_slice();
+        let raw = Box::into_raw(boxed);
+        let storage = unsafe { (*raw).as_mut_ptr() as *mut u8 };
+        Some(Self {
+            storage: NonNull::new(storage)?,
+            size,
+            pos: 0,
+            raw,
+        })
     }
 
-    // Allocate a new buffer
-    let alloc_size = (size + mem::size_of::<BufNode>()).max(1024);
-    let layout = Layout::from_size_align(alloc_size, 8).map_err(|_| AllocError)?;
-    let raw = self.allocator.allocate(layout)?;
-    let buf = raw.as_ptr();
-
-    unsafe {
-      let buf_ptr = buf as *mut u8;
-      buf_ptr
-        .cast::<BufNode>()
-        .write(BufNode { size: alloc_size });
-      self
-        .buffers
-        .push_front(NonNull::new_unchecked(buf_ptr.cast()));
-      let base = buf_ptr.add(mem::size_of::<BufNode>());
-      let aligned = Self::align_up(base as usize, align);
-      self.offset = aligned + size - base as usize;
-      Ok(aligned as *mut u8)
+    fn alloc(&mut self, size: usize, align: usize) -> Option<NonNull<u8>> {
+        if size == 0 {
+            return Some(NonNull::dangling());
+        }
+        let aligned = (self.pos + align - 1) & !(align - 1);
+        if aligned + size > self.size {
+            return None;
+        }
+        let ptr = unsafe { self.storage.as_ptr().add(aligned) };
+        self.pos = aligned + size;
+        Some(unsafe { NonNull::new_unchecked(ptr) })
     }
-  }
 
-  pub fn alloc<T>(&mut self, value: T) -> Result<&mut T, AllocError> {
-    let layout = Layout::new::<T>();
-    let ptr = self.ensure_capacity(layout)?;
-    unsafe {
-      let typed = ptr.cast::<T>();
-      ptr::write(typed, value);
-      Ok(&mut *typed)
+    fn try_retract(&mut self, ptr: NonNull<u8>, size: usize) -> bool {
+        if size == 0 {
+            return true;
+        }
+        let start = self.storage.as_ptr() as usize;
+        let off = ptr.as_ptr() as usize - start;
+        if off + size == self.pos {
+            self.pos = off;
+            true
+        } else {
+            false
+        }
     }
-  }
 
-  pub fn alloc_default<T: Default>(&mut self) -> Result<&mut T, AllocError> {
-    self.alloc(T::default())
-  }
-
-  pub fn alloc_with<T>(&mut self, f: impl FnOnce() -> T) -> Result<&mut T, AllocError> {
-    self.alloc(f())
-  }
-
-  pub fn alloc_slice_copy<T: Copy>(&mut self, data: &[T]) -> Result<&mut [T], AllocError> {
-    let layout = Layout::array::<T>(data.len()).map_err(|_| AllocError)?;
-    let ptr = self.ensure_capacity(layout)?;
-    unsafe {
-      let dst = ptr.cast::<T>();
-      ptr::copy_nonoverlapping(data.as_ptr(), dst, data.len());
-      Ok(core::slice::from_raw_parts_mut(dst, data.len()))
+    fn is_empty(&self) -> bool {
+        self.pos == 0
     }
-  }
-
-  pub fn alloc_slice_fill<T>(
-    &mut self,
-    len: usize,
-    mut f: impl FnMut(usize) -> T,
-  ) -> Result<&mut [T], AllocError> {
-    let layout = Layout::array::<T>(len).map_err(|_| AllocError)?;
-    let ptr = self.ensure_capacity(layout)?;
-    unsafe {
-      let dst = ptr.cast::<T>();
-      for i in 0..len {
-        dst.add(i).write(f(i));
-      }
-      Ok(core::slice::from_raw_parts_mut(dst, len))
-    }
-  }
-
-  fn free_all_buffers(&mut self) {
-    while let Some(ptr) = self.buffers.pop_front() {
-      unsafe {
-        let size = ptr.as_ref().size;
-        let layout = Layout::from_size_align_unchecked(size, 8);
-        self.allocator.deallocate(ptr.cast(), layout);
-      }
-    }
-    self.offset = 0;
-  }
 }
 
-impl<A: Allocator> Drop for Arena<A> {
-  fn drop(&mut self) {
-    self.free_all_buffers();
-  }
+impl Drop for Chunk {
+    fn drop(&mut self) {
+        unsafe { drop(Box::from_raw(self.raw)); }
+    }
 }
+
+/// Untyped bump arena.
+pub struct RawArena {
+    default_chunk_size: usize,
+    chunks: RefCell<Vec<Chunk>>,
+}
+
+impl RawArena {
+    /// Default chunk size used when none is specified.
+    pub const DEFAULT_CHUNK_SIZE: usize = 4096;
+
+    /// Create a new empty arena using [`DEFAULT_CHUNK_SIZE`].
+    pub fn new() -> Self {
+        Self::with_chunk_size(Self::DEFAULT_CHUNK_SIZE)
+    }
+
+    /// Create a new arena with a custom default chunk size.
+    pub fn with_chunk_size(chunk_size: usize) -> Self {
+        Self { default_chunk_size: chunk_size, chunks: RefCell::new(Vec::new()) }
+    }
+
+    pub fn alloc<T>(&self, value: T) -> Option<&mut T> {
+        let layout = Layout::new::<T>();
+        let ptr = self.alloc_raw(layout)?;
+        unsafe {
+            let typed = ptr.as_ptr() as *mut T;
+            ptr::write(typed, value);
+            Some(&mut *typed)
+        }
+    }
+
+    pub fn alloc_slice_with<T>(&self, len: usize, mut f: impl FnMut(usize) -> T) -> Option<&mut [T]> {
+        if len == 0 {
+            return Some(&mut []);
+        }
+        let layout = Layout::array::<T>(len).ok()?;
+        let ptr = self.alloc_raw(layout)?;
+        unsafe {
+            let dst = ptr.as_ptr() as *mut T;
+            for i in 0..len {
+                dst.add(i).write(f(i));
+            }
+            Some(slice::from_raw_parts_mut(dst, len))
+        }
+    }
+
+    pub fn alloc_slice_copy<T: Copy>(&self, values: &[T]) -> Option<&mut [T]> {
+        if values.is_empty() {
+            return Some(&mut []);
+        }
+        let layout = Layout::array::<T>(values.len()).ok()?;
+        let ptr = self.alloc_raw(layout)?;
+        unsafe {
+            let dst = ptr.as_ptr() as *mut T;
+            ptr::copy_nonoverlapping(values.as_ptr(), dst, values.len());
+            Some(slice::from_raw_parts_mut(dst, values.len()))
+        }
+    }
+
+    pub fn alloc_str(&self, string: &str) -> Option<&mut str> {
+        if string.is_empty() {
+            let empty = self.alloc_slice_copy(&[])?;
+            return Some(unsafe { core::str::from_utf8_unchecked_mut(empty) });
+        }
+        let bytes = self.alloc_slice_copy(string.as_bytes())?;
+        Some(unsafe { core::str::from_utf8_unchecked_mut(bytes) })
+    }
+
+    pub fn alloc_raw(&self, layout: Layout) -> Option<NonNull<u8>> {
+        if layout.size() > isize::MAX as usize {
+            return None;
+        }
+        let mut chunks = self.chunks.borrow_mut();
+        for chunk in chunks.iter_mut() {
+            if let Some(ptr) = chunk.alloc(layout.size(), layout.align()) {
+                return Some(ptr);
+            }
+        }
+        let needed_size = layout.size().max(self.default_chunk_size);
+        // Grow the chunk to the next power of two so subsequent allocations
+        // have room without immediately requiring another chunk.
+        let alloc_size = needed_size
+            .checked_next_power_of_two()
+            .unwrap_or(needed_size)
+            .min(isize::MAX as usize);
+        if alloc_size < needed_size {
+            return None;
+        }
+        let mut new_chunk = Chunk::new(alloc_size)?;
+        let ptr = new_chunk.alloc(layout.size(), layout.align())?;
+        chunks.push(new_chunk);
+        Some(ptr)
+    }
+
+    pub fn try_dealloc<T>(&self, ptr: &mut T) -> bool {
+        let raw = NonNull::new(ptr as *mut T as *mut u8).unwrap();
+        let size = mem::size_of::<T>();
+        if size == 0 { return true; }
+        let mut chunks = self.chunks.borrow_mut();
+        for chunk in chunks.iter_mut() {
+            if chunk.try_retract(raw, size) { return true; }
+        }
+        false
+    }
+
+    pub fn try_dealloc_slice<T>(&self, slice: &mut [T]) -> bool {
+        if slice.is_empty() { return true; }
+        let raw = NonNull::new(slice.as_mut_ptr() as *mut u8).unwrap();
+        let size = mem::size_of::<T>() * slice.len();
+        let mut chunks = self.chunks.borrow_mut();
+        for chunk in chunks.iter_mut() {
+            if chunk.try_retract(raw, size) { return true; }
+        }
+        false
+    }
+
+    pub fn stats(&self) -> ArenaStats {
+        let chunks = self.chunks.borrow();
+        let mut total_size = 0;
+        let mut total_used = 0;
+        let mut empty_chunks = 0;
+        for chunk in chunks.iter() {
+            total_size += chunk.size;
+            total_used += chunk.pos;
+            if chunk.is_empty() { empty_chunks += 1; }
+        }
+        ArenaStats {
+            total_chunks: chunks.len(),
+            total_size,
+            total_used,
+            empty_chunks,
+            default_chunk_size: self.default_chunk_size,
+        }
+    }
+
+    pub fn clear(&self) {
+        let mut chunks = self.chunks.borrow_mut();
+        for chunk in chunks.iter_mut() {
+            chunk.pos = 0;
+        }
+    }
+
+    pub fn contains(&self, ptr: NonNull<u8>) -> bool {
+        let chunks = self.chunks.borrow();
+        chunks.iter().any(|chunk| {
+            let start = chunk.storage.as_ptr() as usize;
+            let end = start + chunk.size;
+            let addr = ptr.as_ptr() as usize;
+            addr >= start && addr < end
+        })
+    }
+
+    pub fn compact(&self) {
+        let mut chunks = self.chunks.borrow_mut();
+        chunks.retain(|c| !c.is_empty());
+    }
+}
+
+impl Default for RawArena {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Information about arena memory usage.
+#[derive(Debug)]
+pub struct ArenaStats {
+    pub total_chunks: usize,
+    pub total_size: usize,
+    pub total_used: usize,
+    pub empty_chunks: usize,
+    pub default_chunk_size: usize,
+}
+
+impl ArenaStats {
+    pub fn utilization(&self) -> f32 {
+        if self.total_size == 0 { 0.0 } else { self.total_used as f32 / self.total_size as f32 }
+    }
+
+    pub fn average_chunk_utilization(&self) -> f32 {
+        if self.total_chunks == 0 { 0.0 } else { self.utilization() }
+    }
+}
+

--- a/crates/sable-arena/src/interner.rs
+++ b/crates/sable-arena/src/interner.rs
@@ -5,20 +5,20 @@ use std::{
 
 use crate::arena::RawArena;
 
-pub struct Interner<'intern, T, const CHUNK_SIZE: usize = 4096>
+pub struct Interner<'intern, T>
 where
   T: Eq + Hash + ?Sized,
 {
-  backing: &'intern RawArena<CHUNK_SIZE>,
+  backing: &'intern RawArena,
   lookup: HashMap<&'intern T, &'intern T>,
 }
 
-impl<'intern, T, const CHUNK_SIZE: usize> Interner<'intern, T, CHUNK_SIZE>
+impl<'intern, T> Interner<'intern, T>
 where
   T: Eq + Hash + ?Sized + 'intern,
   for<'a> &'a T: Hash,
 {
-  pub fn new(backing: &'intern RawArena<CHUNK_SIZE>) -> Self {
+  pub fn new(backing: &'intern RawArena) -> Self {
     Self {
       backing,
       lookup: HashMap::new(),
@@ -36,7 +36,7 @@ where
   }
 }
 
-pub type StrInterner<'intern, const CHUNK_SIZE: usize = 4096> = Interner<'intern, str, CHUNK_SIZE>;
+pub type StrInterner<'intern> = Interner<'intern, str>;
 
 #[cfg(test)]
 mod tests {

--- a/crates/sable-arena/src/lib.rs
+++ b/crates/sable-arena/src/lib.rs
@@ -1,8 +1,7 @@
-#![feature(allocator_api)]
 
 pub mod arena;
 pub mod interner;
 #[cfg(test)]
 mod tests;
 
-pub type Arena = arena::RawArena<4096>;
+pub type Arena = arena::RawArena;

--- a/crates/sable-arena/src/tests.rs
+++ b/crates/sable-arena/src/tests.rs
@@ -2,7 +2,7 @@ use crate::arena::RawArena;
 
 #[test]
 fn test_basic_allocation() {
-  let arena = RawArena::<1024>::new();
+  let arena = RawArena::with_chunk_size(1024);
 
   let ref1 = arena.alloc(42).unwrap();
   let ref2 = arena.alloc(24).unwrap();
@@ -16,7 +16,7 @@ fn test_basic_allocation() {
 
 #[test]
 fn test_slice_allocation_copy() {
-  let arena = RawArena::<1024>::new();
+  let arena = RawArena::with_chunk_size(1024);
 
   let values = [1, 2, 3, 4, 5];
   let slice_ref = arena.alloc_slice_copy(&values).unwrap();
@@ -28,7 +28,7 @@ fn test_slice_allocation_copy() {
 
 #[test]
 fn test_slice_allocation_with_closure() {
-  let arena = RawArena::<1024>::new();
+  let arena = RawArena::with_chunk_size(1024);
 
   let slice_ref = arena.alloc_slice_with(5, |i| i * 2).unwrap();
 
@@ -39,7 +39,7 @@ fn test_slice_allocation_with_closure() {
 
 #[test]
 fn test_string_allocation() {
-  let arena = RawArena::<1024>::new();
+  let arena = RawArena::with_chunk_size(1024);
 
   let text = arena.alloc_str("Hello, world!").unwrap();
   assert_eq!(text, "Hello, world!");
@@ -50,7 +50,7 @@ fn test_string_allocation() {
 
 #[test]
 fn test_soft_cleanup() {
-  let arena = RawArena::<1024>::new();
+  let arena = RawArena::with_chunk_size(1024);
 
   let ref1 = arena.alloc(42).unwrap();
   let ref2 = arena.alloc(24).unwrap();
@@ -67,7 +67,7 @@ fn test_soft_cleanup() {
 
 #[test]
 fn test_mixed_type_allocation() {
-  let arena = RawArena::<1024>::new();
+  let arena = RawArena::with_chunk_size(1024);
 
   let int_ref = arena.alloc(42i32).unwrap();
   let float_ref = arena.alloc(3.14f64).unwrap();
@@ -84,7 +84,7 @@ fn test_mixed_type_allocation() {
 
 #[test]
 fn test_zero_sized_types() {
-  let arena = RawArena::<1024>::new();
+  let arena = RawArena::with_chunk_size(1024);
 
   #[derive(Debug, PartialEq)]
   struct ZeroSized;
@@ -98,7 +98,7 @@ fn test_zero_sized_types() {
 
 #[test]
 fn test_large_allocation() {
-  let arena = RawArena::<64>::new(); // Small chunks
+  let arena = RawArena::with_chunk_size(64); // Small chunks
 
   let large_array = [1u8; 128]; // Larger than chunk size
   let slice_ref = arena.alloc_slice_copy(&large_array).unwrap();
@@ -109,7 +109,7 @@ fn test_large_allocation() {
 
 #[test]
 fn test_clear() {
-  let arena = RawArena::<1024>::new();
+  let arena = RawArena::with_chunk_size(1024);
 
   let _ref1 = arena.alloc(42).unwrap();
   let _ref2 = arena.alloc(24).unwrap();
@@ -125,7 +125,7 @@ fn test_clear() {
 
 #[test]
 fn test_non_copy_types_with_closure() {
-  let arena = RawArena::<1024>::new();
+  let arena = RawArena::with_chunk_size(1024);
 
   // Test with non-Copy types
   let strings = arena

--- a/crates/sable-common/src/ty/mod.rs
+++ b/crates/sable-common/src/ty/mod.rs
@@ -6,5 +6,4 @@ pub mod def;
 pub mod resolution;
 pub mod types;
 
-pub type TypeInterner<'intern, const CHUNK_SIZE: usize = 4096> =
-  Interner<'intern, Type, CHUNK_SIZE>;
+pub type TypeInterner<'intern> = Interner<'intern, Type>;


### PR DESCRIPTION
## Summary
- implement `RawArena` with a configurable chunk size instead of a const generic
- adjust interner and type interner to use the updated arena
- update tests for the new API

## Testing
- `cargo check -p sable-arena`
- `cargo test -p sable-arena -- --nocapture`
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_686d8f6d95388333bc3cc98425cbe66f