### PR TITLE
Fix unterminated comment handling

### DIFF
--- a/crates/sable-ast/src/token.rs
+++ b/crates/sable-ast/src/token.rs
@@ -9,6 +9,7 @@ pub enum TokenError {
   UnknownCharacter,
   InvalidInteger,
   InvalidFloat,
+  UnterminatedComment,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]

--- a/crates/sable-errors/src/lex_error/comment_error.rs
+++ b/crates/sable-errors/src/lex_error/comment_error.rs
@@ -1,0 +1,29 @@
+use ariadne::{
+  Label,
+  Report,
+  ReportKind,
+};
+use sable_common::{
+  file::Span,
+  location::Location,
+};
+
+#[derive(Debug)]
+pub struct CommentError<'ctx> {
+  pub lexeme: &'ctx str,
+  pub location: Location<'ctx>,
+}
+
+impl<'ctx> CommentError<'ctx> {
+  pub fn new(lexeme: &'ctx str, location: Location<'ctx>) -> Self {
+    Self { lexeme, location }
+  }
+
+  pub fn report(&self) -> Report<'_, Span<'ctx>> {
+    let span = (*self.location.filename(), self.location.range().clone());
+    Report::build(ReportKind::Error, span.clone())
+      .with_message("Unterminated block comment")
+      .with_label(Label::new(span).with_message("Comment not terminated"))
+      .finish()
+  }
+}

--- a/crates/sable-errors/src/lex_error/mod.rs
+++ b/crates/sable-errors/src/lex_error/mod.rs
@@ -1,2 +1,3 @@
+pub mod comment_error;
 pub mod numeric_error;
 pub mod unknown_char;

--- a/crates/sable-errors/src/parse_error/mod.rs
+++ b/crates/sable-errors/src/parse_error/mod.rs
@@ -7,6 +7,7 @@ use smallvec::SmallVec;
 
 use crate::{
   lex_error::{
+    comment_error::CommentError,
     numeric_error::NumericError,
     unknown_char::UnknownCharError,
   },
@@ -19,6 +20,7 @@ pub enum ParseError<'ctx> {
   UnexpectedToken(UnexpectedTokenError<'ctx>),
   UnknownChar(UnknownCharError<'ctx>),
   NumericError(NumericError<'ctx>),
+  CommentError(CommentError<'ctx>),
 }
 
 impl<'ctx> Reportable<'ctx> for ParseError<'ctx> {
@@ -27,6 +29,7 @@ impl<'ctx> Reportable<'ctx> for ParseError<'ctx> {
       ParseError::UnexpectedToken(unexpected_token) => unexpected_token.report(),
       ParseError::UnknownChar(unknown_char) => unknown_char.report(),
       ParseError::NumericError(numeric_error) => numeric_error.report(),
+      ParseError::CommentError(comment_error) => comment_error.report(),
     }
   }
 }

--- a/crates/sable-parse/src/parser.rs
+++ b/crates/sable-parse/src/parser.rs
@@ -47,6 +47,7 @@ use sable_ast::{
 use sable_common::location::Location;
 use sable_errors::{
   lex_error::{
+    comment_error::CommentError,
     numeric_error::NumericError,
     unknown_char::UnknownCharError,
   },
@@ -115,6 +116,9 @@ where
       )),
       TokenError::InvalidInteger | TokenError::InvalidFloat => {
         ParseError::NumericError(NumericError::new(token.lexeme(), token.location().clone()))
+      }
+      TokenError::UnterminatedComment => {
+        ParseError::CommentError(CommentError::new(token.lexeme(), token.location().clone()))
       }
     }
   }


### PR DESCRIPTION
## Summary
- add `UnterminatedComment` token error
- report unterminated block comment tokens
- surface comment error through parser and error reporting

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68809e34456c8333bf9301adb07116d9