### PR TITLE
Clarify arena allocation and copy semantics

### DIFF
--- a/crates/sable-arena/src/typed_arena.rs
+++ b/crates/sable-arena/src/typed_arena.rs
@@ -1,9 +1,5 @@
 use core::{
-  alloc::{
-    AllocError,
-    Allocator,
-    Layout,
-  },
+  alloc::{AllocError, Allocator, Layout},
   marker::PhantomData,
   ptr::NonNull,
 };
@@ -32,8 +28,18 @@ impl<T> TypedArena<T> {
     self.inner.alloc(value)
   }
 
-  pub fn alloc_copy(&self, value: &T) -> &mut T {
+  pub fn alloc_copy(&self, value: &T) -> &mut T
+  where
+    T: Copy,
+  {
     self.inner.alloc_copy(value)
+  }
+
+  pub fn alloc_clone(&self, value: &T) -> &mut T
+  where
+    T: Clone,
+  {
+    self.inner.alloc_clone(value)
   }
 
   pub fn alloc_slice_with(&self, len: usize, f: impl FnMut(usize) -> T) -> &mut [T] {
@@ -56,6 +62,10 @@ impl<T> TypedArena<T> {
 
   pub fn alloc_str(&self, s: &str) -> &mut str {
     self.inner.alloc_str(s)
+  }
+
+  pub fn clear(&self) {
+    self.inner.clear();
   }
 
   pub fn as_untyped(&self) -> &Arena {

--- a/crates/sable-common/src/interner.rs
+++ b/crates/sable-common/src/interner.rs
@@ -1,13 +1,7 @@
-use std::{
-  cell::RefCell,
-  hash::Hash,
-};
+use std::{cell::RefCell, hash::Hash};
 
 use indexmap::IndexSet;
-use sable_arena::{
-  TypedArena,
-  arena::Arena,
-};
+use sable_arena::{TypedArena, arena::Arena};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
@@ -46,7 +40,7 @@ impl<'intern> StrInterner<'intern> {
 
 pub struct Interner<'intern, T>
 where
-  T: Sized + Eq + Hash,
+  T: Eq + Hash + Copy,
 {
   inner: &'intern TypedArena<T>,
   index: RefCell<IndexSet<&'intern T>>,
@@ -54,7 +48,7 @@ where
 
 impl<'intern, T> Interner<'intern, T>
 where
-  T: Sized + Eq + Hash,
+  T: Eq + Hash + Copy,
 {
   pub fn new(arena: &'intern TypedArena<T>) -> Self {
     Self {
@@ -83,7 +77,7 @@ where
 mod tests {
   use super::*;
 
-  #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+  #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
   struct Point {
     x: i32,
     y: i32,


### PR DESCRIPTION
## Summary
- clarify copying semantics in arena allocator
- expose cloning and clearing helpers on typed arena
- require `Copy` for interner entries

## Testing
- `cargo +nightly test`

------
https://chatgpt.com/codex/tasks/task_e_6891a6372a9c8333aa88cbca7b954bef